### PR TITLE
Lock portrait mode and improve audio

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,21 +29,6 @@
         <div id="environment"></div>
         <img id="creature" alt="Criatura" src="assets/images/stage1.png" />
         <div id="buttons"></div>
-        <audio
-          id="sfx-tap"
-          src="./assets/sounds/tap.wav"
-          preload="auto"
-        ></audio>
-        <audio
-          id="sfx-stage"
-          src="./assets/sounds/stage-change.wav"
-          preload="auto"
-        ></audio>
-        <audio
-          id="sfx-complete"
-          src="./assets/sounds/action-complete.wav"
-          preload="auto"
-        ></audio>
       </main>
 
       <section id="stats" hidden>

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,7 @@
   "start_url": "./",
   "scope": "./",
   "display": "standalone",
+  "orientation": "portrait",
   "background_color": "#000000",
   "theme_color": "#000000",
   "icons": [

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE = "habit-reinforcer-v3";
+const CACHE = "habit-reinforcer-v4";
 const ASSETS = [
   "./",
   "./index.html",

--- a/style.css
+++ b/style.css
@@ -126,6 +126,7 @@ body {
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  padding: 4px;
   border-radius: 50%;
   border: 0;
   background: var(--btn);
@@ -146,7 +147,11 @@ body {
 }
 
 #buttons .action .label {
+  width: 100%;
+  display: block;
   text-align: center;
+  white-space: normal;
+  word-break: break-word;
 }
 
 #buttons .action .count {


### PR DESCRIPTION
## Summary
- force portrait orientation for the app
- play sound effects without interrupting system audio
- use compass emoji default button with counters enabled
- prevent button text from overflowing

## Testing
- `npx prettier --check index.html app.js manifest.json service-worker.js style.css`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d0085eaf8832ea4b4b6f59553de0b