### PR TITLE
Lock orientation once, drag handling and weekly stats

### DIFF
--- a/style.css
+++ b/style.css
@@ -236,6 +236,8 @@ body {
 .drag-handle {
   cursor: grab;
   user-select: none;
+  -webkit-user-select: none;
+  touch-action: none;
 }
 
 .panel input[type="color"] {


### PR DESCRIPTION
## Summary
- lock orientation to portrait once during startup
- avoid text selection during drag-and-drop in settings
- show color picker for each habit button
- chart displays weekly totals for current month

## Testing
- `npx prettier --write app.js`
- `npx prettier --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_689d29866b68832ebc17e3911edc520e