### PR TITLE
docs: clarify intro video autoplay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,5 +20,6 @@ This repository contains a small static web app written in plain JavaScript, HTM
 
 ## Miscellaneous
 
+- The intro video (`#intro-video` in `index.html`) must always autoplay. Keep its `autoplay` attribute so it starts automatically, and avoid changes that interfere with the automatic playback.
 - This file's instructions apply to the entire repository.
 - Leave the working tree clean before finishing.


### PR DESCRIPTION
## Summary
- document in AGENTS instructions that the intro video must keep its autoplay attribute and start automatically

## Testing
- `npx prettier --check AGENTS.md`


------
https://chatgpt.com/codex/tasks/task_e_689d2eed08d4832e9ae4fcda1d7b6128