### PR TITLE
Ensure portrait orientation and always render settings

### DIFF
--- a/app.js
+++ b/app.js
@@ -51,9 +51,14 @@ const lang = navigator.language.startsWith("es") ? "es" : "en";
 document.documentElement.lang = lang;
 const t = (k) => translations[lang][k];
 
-if (screen.orientation && screen.orientation.lock) {
-  screen.orientation.lock("portrait").catch(() => {});
+function lockOrientation() {
+  if (screen.orientation && screen.orientation.lock) {
+    screen.orientation.lock("portrait").catch(() => {});
+  }
 }
+
+lockOrientation();
+window.addEventListener("orientationchange", lockOrientation);
 
 // Config persistente
 const LS_SETTINGS = "habitSettings";
@@ -418,6 +423,7 @@ closeStats.addEventListener("click", () => {
 });
 
 btnSettings.addEventListener("click", () => {
+  renderSettings();
   settingsSheet.hidden = false;
 });
 

--- a/index.html
+++ b/index.html
@@ -13,6 +13,8 @@
     <meta name="theme-color" content="#000000" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="screen-orientation" content="portrait" />
+    <meta name="x5-orientation" content="portrait" />
   </head>
   <body>
     <video


### PR DESCRIPTION
## Summary
- Lock screen orientation to portrait and reapply on change
- Render settings list when opening to show color pickers
- Add portrait orientation meta tags

## Testing
- `npx prettier --check app.js index.html`


------
https://chatgpt.com/codex/tasks/task_e_689d476fb434832e9c242f4ab7a450b2