### PR TITLE
Add confetti effect on stage transitions

### DIFF
--- a/app.js
+++ b/app.js
@@ -255,6 +255,7 @@ function handleAction(label) {
     saveJSON(LS_SETTINGS, settings);
     renderStage();
     playStageSound();
+    playStageParticles();
   }
 
   updateStats();
@@ -301,6 +302,9 @@ function playTapSound() {
 }
 function playStageSound() {
   playSound("stage");
+}
+function playStageParticles() {
+  confetti({ spread: 70, origin: { y: 0.6 } });
 }
 function playCompleteSound() {
   playSound("complete");

--- a/index.html
+++ b/index.html
@@ -88,6 +88,7 @@
       </section>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
     <script src="app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Overlay confetti particles whenever the creature advances a stage
- Load canvas-confetti library in the main page

## Testing
- `npx prettier --check index.html app.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d5587c54c832e8eef39fe79e32d36