### PR TITLE
feat: add notes overlay for decision buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,14 @@
         </div>
       </section>
 
+      <section id="note-sheet" hidden>
+        <div class="panel">
+          <button id="close-note" class="close" aria-label="Cerrar">✕</button>
+          <h2 id="note-title"></h2>
+          <textarea id="note-text" rows="6"></textarea>
+        </div>
+      </section>
+
       <section id="storage-error" hidden>
         <div class="panel">
           <p id="storage-error-text"></p>

--- a/style.css
+++ b/style.css
@@ -171,7 +171,8 @@ body {
 /* Paneles superpuestos */
 #stats,
 #settings,
-#storage-error {
+#storage-error,
+#note-sheet {
   position: absolute;
   inset: 0;
   display: grid;
@@ -279,6 +280,18 @@ body {
   position: absolute;
   top: 8px;
   right: 8px;
+}
+
+#note-sheet #close-note {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+}
+
+#note-text {
+  width: 100%;
+  min-height: 120px;
+  resize: vertical;
 }
 
 @keyframes float {


### PR DESCRIPTION
## Summary
- allow users to long-press action buttons to open a note overlay
- persist per-button notes in local storage and clear them on reset or cache refresh
- style note overlay and textarea for comfortable editing

## Testing
- `npx prettier --check app.js index.html style.css`


------
https://chatgpt.com/codex/tasks/task_e_689d6101dbbc832ea337ebf4c581c1d1