### PR TITLE
Fix color picker visibility on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -245,11 +245,12 @@ body {
 }
 
 .panel input[type="color"] {
-  width: 32px;
-  height: 32px;
+  width: 44px;
+  height: 44px;
   padding: 0;
   border: 0;
   background: none;
+  flex-shrink: 0;
 }
 #button-list input {
   width: 100%;


### PR DESCRIPTION
## Summary
- enlarge color picker controls so they are tappable on mobile

## Testing
- `npx prettier --check style.css`
- `npm test >/tmp/unit-test.log && tail -n 20 /tmp/unit-test.log`


------
https://chatgpt.com/codex/tasks/task_e_689d66944860832e8afa0637797bda7a