### PR TITLE
fix: show color picker on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -249,7 +249,6 @@ body {
   height: 44px;
   padding: 0;
   border: 0;
-  background: none;
   flex-shrink: 0;
 }
 #button-list input {


### PR DESCRIPTION
## Summary
- remove color input background reset so color swatch is visible on mobile

## Testing
- `npx prettier --check style.css`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d6a1fbb10832e8b4504b1648f869f