### PR TITLE
Ensure stage 1 video autoplay

### DIFF
--- a/app.js
+++ b/app.js
@@ -343,6 +343,7 @@ function renderStage() {
     } else {
       creatureEl.src = "assets/videos/stage1.mp4";
     }
+    creatureEl.play().catch(() => {});
   } else {
     if (creatureEl.tagName !== "IMG") {
       const img = document.createElement("img");


### PR DESCRIPTION
## Summary
- Ensure stage 1 video is always played by invoking `play()` after rendering.

## Testing
- `npx prettier --check app.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e0e10beac832e855ed357d1729eed