### PR TITLE
Fix intro autoplay and enable iOS video playback

### DIFF
--- a/app.js
+++ b/app.js
@@ -222,7 +222,16 @@ renderSettings();
 updateStats();
 if (introVideo) {
   introVideo.removeAttribute("controls");
-  introVideo.play().catch(() => {});
+  introVideo.muted = true;
+  introVideo.setAttribute("muted", "");
+  introVideo.setAttribute("playsinline", "");
+  introVideo.setAttribute("webkit-playsinline", "");
+  const playIntro = () => introVideo.play().catch(() => {});
+  if (introVideo.readyState >= 2) {
+    playIntro();
+  } else {
+    introVideo.addEventListener("canplay", playIntro, { once: true });
+  }
   introVideo.addEventListener("ended", () => {
     introVideo.classList.add("fade-out");
     introVideo.addEventListener(
@@ -336,12 +345,21 @@ function renderStage() {
       video.autoplay = true;
       video.loop = true;
       video.muted = true;
+      video.setAttribute("muted", "");
       video.playsInline = true;
+      video.setAttribute("playsinline", "");
+      video.setAttribute("webkit-playsinline", "");
       video.src = "assets/videos/stage1.mov";
       creatureEl.replaceWith(video);
       creatureEl = video;
     } else {
       creatureEl.src = "assets/videos/stage1.mov";
+      creatureEl.muted = true;
+      creatureEl.setAttribute("muted", "");
+      creatureEl.setAttribute("playsinline", "");
+      creatureEl.setAttribute("webkit-playsinline", "");
+      creatureEl.autoplay = true;
+      creatureEl.loop = true;
     }
     creatureEl.play().catch(() => {});
   } else {

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
       autoplay
       muted
       playsinline
+      webkit-playsinline
     ></video>
     <div id="app">
       <header id="hud">
@@ -39,6 +40,7 @@
           loop
           muted
           playsinline
+          webkit-playsinline
         ></video>
         <div id="buttons"></div>
       </main>


### PR DESCRIPTION
## Summary
- Ensure intro video autoplays and plays inline on iOS
- Set creature video attributes and playback for mobile compatibility

## Testing
- `npx prettier --check index.html app.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689eb4f376d8832e9cacb3a4936aa973