### PR TITLE
Improve video autoplay reliability

### DIFF
--- a/app.js
+++ b/app.js
@@ -232,6 +232,7 @@ if (introVideo) {
   } else {
     introVideo.addEventListener("canplay", playIntro, { once: true });
   }
+  document.addEventListener("pointerdown", playIntro, { once: true });
   introVideo.addEventListener("ended", () => {
     introVideo.classList.add("fade-out");
     introVideo.addEventListener(
@@ -361,7 +362,13 @@ function renderStage() {
       creatureEl.autoplay = true;
       creatureEl.loop = true;
     }
-    creatureEl.play().catch(() => {});
+    const playCreature = () => creatureEl.play().catch(() => {});
+    if (creatureEl.readyState >= 2) {
+      playCreature();
+    } else {
+      creatureEl.addEventListener("canplay", playCreature, { once: true });
+    }
+    document.addEventListener("pointerdown", playCreature, { once: true });
   } else {
     if (creatureEl.tagName !== "IMG") {
       const img = document.createElement("img");

--- a/style.css
+++ b/style.css
@@ -33,7 +33,8 @@ body {
   inset: 0;
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
+  background: #000000;
   z-index: 10;
   opacity: 1;
   transition: opacity 0.15s ease;


### PR DESCRIPTION
## Summary
- Add pointer interaction fallback to guarantee autoplay for intro and creature videos
- Scale intro video using `object-fit: contain` for full visibility

## Testing
- `npx prettier --check app.js style.css`


------
https://chatgpt.com/codex/tasks/task_e_689ebca19a88832e96dc7961fa5b022f