### PR TITLE
Reorder habit controls and add advanced section

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ const translations = {
     reset: "Reset",
     refresh: "Clear Cache",
     close: "Close",
+    advanced: "Advanced",
     today: "Today",
     week: "Week",
     month: "Month",
@@ -32,6 +33,7 @@ const translations = {
     reset: "Renacer",
     refresh: "Borrar Cache",
     close: "Cerrar",
+    advanced: "Avanzado",
     today: "Hoy",
     week: "Semana",
     month: "Mes",
@@ -124,6 +126,7 @@ const lblMonth = document.getElementById("lbl-month");
 const lblTotal = document.getElementById("lbl-total");
 const settingsTitle = document.getElementById("settings-title");
 const settingsHabits = document.getElementById("settings-habits");
+const settingsAdvanced = document.getElementById("settings-advanced");
 const storageErrorSheet = document.getElementById("storage-error");
 const storageErrorText = document.getElementById("storage-error-text");
 const chartCanvas = document.getElementById("chart-week");
@@ -199,6 +202,7 @@ btnSettings.setAttribute("aria-label", t("settings"));
 closeStats.setAttribute("aria-label", t("close"));
 settingsTitle.textContent = t("settings");
 settingsHabits.textContent = t("habits");
+settingsAdvanced.textContent = t("advanced");
 newLabel.placeholder = t("buttonName");
 addButton.textContent = t("add");
 resetApp.textContent = t("reset");

--- a/index.html
+++ b/index.html
@@ -76,11 +76,14 @@
           <ul id="button-list"></ul>
           <div class="row">
             <input id="new-label" type="text" placeholder="Nombre del botón" />
-            <button id="add-button">Agregar</button>
             <input id="new-color" type="color" value="#ffcc66" />
+            <button id="add-button">Agregar</button>
           </div>
           <div class="row">
             <button id="toggle-counts">Mostrar contadores</button>
+          </div>
+          <h3 id="settings-advanced">Avanzado</h3>
+          <div class="row">
             <button id="reset-app">Renacer</button>
             <button id="refresh-app">Borrar Cache</button>
           </div>


### PR DESCRIPTION
## Summary
- Place new button color picker before the add button
- Isolate counters toggle and add an "Advanced" section for reset and cache actions
- Localize new advanced heading in English and Spanish

## Testing
- `npx prettier --check index.html app.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ec0d8ddc4832e9a37fdf6576dfb24