### PR TITLE
Adjust stage progression thresholds

### DIFF
--- a/app.js
+++ b/app.js
@@ -94,7 +94,7 @@ settings.buttons = settings.buttons
 saveJSON(LS_SETTINGS, settings);
 let logs = loadJSON(LS_LOG, []);
 let notes = loadJSON(LS_NOTES, {});
-const thresholds = [2, 3, 4, 5, 6]; // 1→2, 2→3, 3→4, 4→5, 5→6
+const thresholds = [5, 20, 100, 250, 500]; // 1→2, 2→3, 3→4, 4→5, 5→6
 
 // Elementos
 let creatureEl = document.getElementById("creature");


### PR DESCRIPTION
## Summary
- update stage advancement thresholds to 5, 20, 100, 250, and 500 entries

## Testing
- `npx prettier --check app.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ec4b99798832e9d5be8a057554258