### PR TITLE
Track button counts separately and add double-tap undo

### DIFF
--- a/style.css
+++ b/style.css
@@ -143,6 +143,8 @@ body {
     box-shadow 0.2s ease,
     background 0.3s ease;
   transform: translateY(var(--arc-y));
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 #buttons .action:hover {


### PR DESCRIPTION
## Summary
- assign persistent ids to buttons so counters survive renames and identical labels
- allow slow double presses to undo the last count
- prevent text selection when opening note menus

## Testing
- `npx prettier --check app.js style.css`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f3d57dee4832eb4c497a709bdf2b7