### PR TITLE
Limit habit labels and add counter controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,6 +98,12 @@
           <button id="close-note" class="close" aria-label="Cerrar">✕</button>
           <h2 id="note-title"></h2>
           <textarea id="note-text" rows="6"></textarea>
+          <h3>Contador</h3>
+          <div class="row">
+            <button id="note-count-minus">-</button>
+            <span id="note-count">0</span>
+            <button id="note-count-plus">+</button>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- Restrict habit button labels to 8 characters
- Replace double-tap undo with counter controls in note overlay
- Allow adjusting button counts with new plus/minus controls

## Testing
- `npx prettier --check app.js index.html`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f631d63f4832e84836be941c9be68