### PR TITLE
Adjust button label and counter font sizes

### DIFF
--- a/app.js
+++ b/app.js
@@ -367,6 +367,14 @@ function renderButtons() {
     const labelSpan = document.createElement("span");
     labelSpan.className = "label";
     labelSpan.textContent = b.label.slice(0, LABEL_LIMIT);
+    const trimmedLabel = labelSpan.textContent.trim();
+    if (
+      /^\p{Extended_Pictographic}(?:\uFE0F|\u200D\p{Extended_Pictographic})*$/u.test(
+        trimmedLabel,
+      )
+    ) {
+      labelSpan.classList.add("emoji-only");
+    }
     btn.appendChild(labelSpan);
 
     if (settings.showButtonCounts) {

--- a/style.css
+++ b/style.css
@@ -160,9 +160,13 @@ body {
   word-break: break-word;
 }
 
+#buttons .action .label.emoji-only {
+  font-size: 32px;
+}
+
 #buttons .action .count {
   margin-top: 2px;
-  font-size: 14px;
+  font-size: 12px;
   text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- Reduce button counter font size for a lighter appearance.
- Detect single emoji labels and enlarge them for better readability.

## Testing
- `npx prettier --check app.js style.css`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f6afbdffc832eab3fe159b8c33fdf