### PR TITLE
Preserve local data on cache clear

### DIFF
--- a/app.js
+++ b/app.js
@@ -722,7 +722,6 @@ refreshApp.addEventListener("click", async () => {
       await caches.delete(name);
     }
   }
-  localStorage.removeItem(LS_NOTES);
   location.reload();
 });
 


### PR DESCRIPTION
## Summary
- Ensure cache clear reloads PWA without wiping local storage

## Testing
- `npx prettier --check app.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f7ebf1ed0832e8aa3feb92a006ab0