### PR TITLE
Add stage progress counter

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
       webkit-playsinline
     ></video>
     <div id="app">
+      <div id="progress-counter" hidden></div>
       <header id="hud">
         <button id="btn-settings" aria-label="Configuración">⚙️</button>
         <button id="btn-stats" aria-label="Mostrar estadísticas">📊</button>
@@ -84,6 +85,9 @@
             <button id="toggle-counts">Mostrar contadores</button>
           </div>
           <h3 id="settings-advanced">Avanzado</h3>
+          <div class="row">
+            <button id="toggle-progress">Mostrar progreso</button>
+          </div>
           <div class="row">
             <button id="reset-app">Renacer</button>
             <button id="refresh-app">Borrar Cache</button>

--- a/style.css
+++ b/style.css
@@ -83,6 +83,19 @@ body {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
 }
 
+#progress-counter {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  font-size: 14px;
+  background: rgba(0, 0, 0, 0.4);
+  padding: 6px 10px;
+  border-radius: 10px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(4px);
+  z-index: 3;
+}
+
 #scene {
   position: relative;
   height: 100%;


### PR DESCRIPTION
## Summary
- add top-left stage progress counter that appears past 85%
- allow always-on counter via advanced settings toggle
- style counter to match HUD buttons

## Testing
- `npx prettier --check index.html style.css app.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a15d3daabc832e99659007aeba0163