### PR TITLE
Restyle buttons and move progress visibility toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -89,7 +89,7 @@ const uuid = () =>
     : String(Date.now() + Math.random());
 
 const defaultSettings = {
-  buttons: [{ id: uuid(), label: t("defaultButton"), color: "#ffcc66" }],
+  buttons: [{ id: uuid(), label: t("defaultButton"), color: "#0044aa" }],
   showButtonCounts: true,
   showProgressCounter: false,
   stage: 1,
@@ -99,7 +99,7 @@ const defaultSettings = {
 const LABEL_LIMIT = 8;
 const MAX_BUTTONS = 5;
 const defaultColors = [
-  "#ffcc66",
+  "#0044aa",
   "#66ff66",
   "#66ccff",
   "#ff6666",
@@ -148,6 +148,7 @@ const newColor = document.getElementById("new-color");
 const buttonList = document.getElementById("button-list");
 const toggleCounts = document.getElementById("toggle-counts");
 const toggleProgress = document.getElementById("toggle-progress");
+const lblProgress = document.getElementById("lbl-progress");
 const closeSettings = document.getElementById("close-settings");
 const resetApp = document.getElementById("reset-app");
 const refreshApp = document.getElementById("refresh-app");
@@ -262,9 +263,11 @@ chartRange.addEventListener("change", drawChart);
 toggleCounts.textContent = settings.showButtonCounts
   ? t("hideCounts")
   : t("showCounts");
-toggleProgress.textContent = settings.showProgressCounter
+lblProgress.textContent = settings.showProgressCounter
   ? t("hideProgress")
   : t("showProgress");
+toggleProgress.textContent = settings.showProgressCounter ? "👁️" : "👁‍🚫";
+toggleProgress.setAttribute("aria-label", lblProgress.textContent);
 storageErrorText.textContent = t("storageError");
 
 // Init
@@ -419,7 +422,7 @@ function renderButtons() {
       btn.appendChild(countSpan);
     }
 
-    btn.style.background = b.color || "#ffcc66";
+    btn.style.background = b.color || "#0044aa";
     let holdTimeout;
     let held = false;
     btn.addEventListener("pointerdown", (e) => {
@@ -734,9 +737,11 @@ toggleCounts.addEventListener("click", () => {
 toggleProgress.addEventListener("click", () => {
   settings.showProgressCounter = !settings.showProgressCounter;
   saveJSON(LS_SETTINGS, settings);
-  toggleProgress.textContent = settings.showProgressCounter
+  lblProgress.textContent = settings.showProgressCounter
     ? t("hideProgress")
     : t("showProgress");
+  toggleProgress.textContent = settings.showProgressCounter ? "👁️" : "👁‍🚫";
+  toggleProgress.setAttribute("aria-label", lblProgress.textContent);
   updateProgressCounter();
 });
 
@@ -794,9 +799,11 @@ function renderSettings() {
   toggleCounts.textContent = settings.showButtonCounts
     ? t("hideCounts")
     : t("showCounts");
-  toggleProgress.textContent = settings.showProgressCounter
+  lblProgress.textContent = settings.showProgressCounter
     ? t("hideProgress")
     : t("showProgress");
+  toggleProgress.textContent = settings.showProgressCounter ? "👁️" : "👁‍🚫";
+  toggleProgress.setAttribute("aria-label", lblProgress.textContent);
 
   buttonList.innerHTML = "";
   settings.buttons.forEach((b, idx) => {
@@ -823,7 +830,7 @@ function renderSettings() {
 
     const color = document.createElement("input");
     color.type = "color";
-    color.value = b.color || "#ffcc66";
+    color.value = b.color || "#0044aa";
     color.addEventListener("input", () => {
       settings.buttons[idx].color = color.value;
       saveJSON(LS_SETTINGS, settings);

--- a/index.html
+++ b/index.html
@@ -78,16 +78,19 @@
           <ul id="button-list"></ul>
           <div class="row">
             <input id="new-label" type="text" placeholder="Nombre del botón" />
-            <input id="new-color" type="color" value="#ffcc66" />
+            <input id="new-color" type="color" value="#0044aa" />
             <button id="add-button">Agregar</button>
           </div>
           <div class="row">
             <button id="toggle-counts">Mostrar contadores</button>
           </div>
-          <h3 id="settings-advanced">Avanzado</h3>
           <div class="row">
-            <button id="toggle-progress">Mostrar progreso</button>
+            <span id="lbl-progress">Mostrar progreso</span>
+            <button id="toggle-progress" aria-label="Mostrar progreso">
+              👁‍🚫
+            </button>
           </div>
+          <h3 id="settings-advanced">Avanzado</h3>
           <div class="row">
             <button id="reset-app">Renacer</button>
             <button id="refresh-app">Borrar Cache</button>

--- a/style.css
+++ b/style.css
@@ -1,8 +1,8 @@
 :root {
   --bg: #000000;
   --panel: rgba(255, 255, 255, 0.85);
-  --accent: #66ccff;
-  --btn: #ffcc66;
+  --accent: #0044aa;
+  --btn: #0044aa;
   --shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
 }
 
@@ -147,7 +147,7 @@ body {
   border-radius: 50%;
   border: 0;
   background: var(--btn);
-  color: #402;
+  color: #ffffff;
   font-weight: 600;
   cursor: pointer;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
@@ -315,6 +315,29 @@ body {
 .panel button:active {
   transform: translateY(2px) scale(0.96);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+#reset-app {
+  background: #ff6666;
+}
+
+#refresh-app {
+  background: #aaaaaa;
+  color: #000000;
+}
+
+#toggle-progress {
+  background: none;
+  color: inherit;
+  padding: 0;
+  box-shadow: none;
+  font-size: 24px;
+}
+
+#toggle-progress:hover,
+#toggle-progress:active {
+  transform: none;
+  box-shadow: none;
 }
 
 #stats #close-stats {


### PR DESCRIPTION
## Summary
- Darkened default UI buttons to deep blue, added custom colors for reset and cache buttons, and adjusted habit button contrast.
- Moved progress visibility control to Habits section with an eye icon toggle.
- Updated default habit button color and logic for progress icon states.

## Testing
- `npx prettier --write index.html style.css app.js`
- `npx prettier --check index.html style.css app.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1612c4bd0832eafacb4dfa0edb95e