### PR TITLE
Refine button styling and toggles

### DIFF
--- a/app.js
+++ b/app.js
@@ -89,7 +89,7 @@ const uuid = () =>
     : String(Date.now() + Math.random());
 
 const defaultSettings = {
-  buttons: [{ id: uuid(), label: t("defaultButton"), color: "#0044aa" }],
+  buttons: [{ id: uuid(), label: t("defaultButton"), color: "#3366cc" }],
   showButtonCounts: true,
   showProgressCounter: false,
   stage: 1,
@@ -99,7 +99,7 @@ const defaultSettings = {
 const LABEL_LIMIT = 8;
 const MAX_BUTTONS = 5;
 const defaultColors = [
-  "#0044aa",
+  "#3366cc",
   "#66ff66",
   "#66ccff",
   "#ff6666",
@@ -147,6 +147,7 @@ newLabel.maxLength = LABEL_LIMIT;
 const newColor = document.getElementById("new-color");
 const buttonList = document.getElementById("button-list");
 const toggleCounts = document.getElementById("toggle-counts");
+const lblCounts = document.getElementById("lbl-counts");
 const toggleProgress = document.getElementById("toggle-progress");
 const lblProgress = document.getElementById("lbl-progress");
 const closeSettings = document.getElementById("close-settings");
@@ -260,9 +261,11 @@ chartRange.innerHTML = `
 `;
 chartRange.value = "month";
 chartRange.addEventListener("change", drawChart);
-toggleCounts.textContent = settings.showButtonCounts
+lblCounts.textContent = settings.showButtonCounts
   ? t("hideCounts")
   : t("showCounts");
+toggleCounts.textContent = settings.showButtonCounts ? "👁️" : "👁‍🚫";
+toggleCounts.setAttribute("aria-label", lblCounts.textContent);
 lblProgress.textContent = settings.showProgressCounter
   ? t("hideProgress")
   : t("showProgress");
@@ -422,7 +425,7 @@ function renderButtons() {
       btn.appendChild(countSpan);
     }
 
-    btn.style.background = b.color || "#0044aa";
+    btn.style.background = b.color || "#3366cc";
     let holdTimeout;
     let held = false;
     btn.addEventListener("pointerdown", (e) => {
@@ -697,10 +700,17 @@ function drawChart() {
 // HUD y Settings
 hudStatsBtn.addEventListener("click", () => {
   statsSheet.hidden = !statsSheet.hidden;
+  hudStatsBtn.textContent = statsSheet.hidden ? "👁‍🚫" : "👁️";
+  hudStatsBtn.setAttribute(
+    "aria-label",
+    statsSheet.hidden ? t("showStats") : t("stats"),
+  );
 });
 
 closeStats.addEventListener("click", () => {
   statsSheet.hidden = true;
+  hudStatsBtn.textContent = "👁‍🚫";
+  hudStatsBtn.setAttribute("aria-label", t("showStats"));
 });
 
 btnSettings.addEventListener("click", () => {
@@ -728,9 +738,11 @@ addButton.addEventListener("click", () => {
 toggleCounts.addEventListener("click", () => {
   settings.showButtonCounts = !settings.showButtonCounts;
   saveJSON(LS_SETTINGS, settings);
-  toggleCounts.textContent = settings.showButtonCounts
+  lblCounts.textContent = settings.showButtonCounts
     ? t("hideCounts")
     : t("showCounts");
+  toggleCounts.textContent = settings.showButtonCounts ? "👁️" : "👁‍🚫";
+  toggleCounts.setAttribute("aria-label", lblCounts.textContent);
   renderButtons();
 });
 
@@ -796,9 +808,11 @@ notePlus.addEventListener("click", () => {
 });
 
 function renderSettings() {
-  toggleCounts.textContent = settings.showButtonCounts
+  lblCounts.textContent = settings.showButtonCounts
     ? t("hideCounts")
     : t("showCounts");
+  toggleCounts.textContent = settings.showButtonCounts ? "👁️" : "👁‍🚫";
+  toggleCounts.setAttribute("aria-label", lblCounts.textContent);
   lblProgress.textContent = settings.showProgressCounter
     ? t("hideProgress")
     : t("showProgress");
@@ -830,7 +844,7 @@ function renderSettings() {
 
     const color = document.createElement("input");
     color.type = "color";
-    color.value = b.color || "#0044aa";
+    color.value = b.color || "#3366cc";
     color.addEventListener("input", () => {
       settings.buttons[idx].color = color.value;
       saveJSON(LS_SETTINGS, settings);

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
       <div id="progress-counter" hidden></div>
       <header id="hud">
         <button id="btn-settings" aria-label="Configuración">⚙️</button>
-        <button id="btn-stats" aria-label="Mostrar estadísticas">📊</button>
+        <button id="btn-stats" aria-label="Mostrar estadísticas">👁‍🚫</button>
       </header>
 
       <main id="scene">
@@ -78,11 +78,14 @@
           <ul id="button-list"></ul>
           <div class="row">
             <input id="new-label" type="text" placeholder="Nombre del botón" />
-            <input id="new-color" type="color" value="#0044aa" />
+            <input id="new-color" type="color" value="#3366cc" />
             <button id="add-button">Agregar</button>
           </div>
           <div class="row">
-            <button id="toggle-counts">Mostrar contadores</button>
+            <span id="lbl-counts">Mostrar contadores</span>
+            <button id="toggle-counts" aria-label="Mostrar contadores">
+              👁‍🚫
+            </button>
           </div>
           <div class="row">
             <span id="lbl-progress">Mostrar progreso</span>

--- a/style.css
+++ b/style.css
@@ -1,8 +1,8 @@
 :root {
   --bg: #000000;
   --panel: rgba(255, 255, 255, 0.85);
-  --accent: #0044aa;
-  --btn: #0044aa;
+  --accent: #3366cc;
+  --btn: #3366cc;
   --shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
 }
 
@@ -147,7 +147,7 @@ body {
   border-radius: 50%;
   border: 0;
   background: var(--btn);
-  color: #ffffff;
+  color: #000000;
   font-weight: 600;
   cursor: pointer;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);


### PR DESCRIPTION
## Summary
- Soften default blue accents and ensure habit buttons use black text
- Use crossed-eye emoji to indicate stats visibility
- Switch counters toggle to eye emoji with cross overlay

## Testing
- `npx prettier --check index.html style.css app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a165faeab4832eb4ae7226e347a12c