### PR TITLE
Restore stats icon and refine settings toggles

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,8 @@ const translations = {
     habits: "Habits",
     add: "Add",
     buttonName: "Button name",
+    counts: "Counts",
+    progress: "Progress",
     showCounts: "Show counts",
     hideCounts: "Hide counts",
     showProgress: "Show progress",
@@ -35,6 +37,8 @@ const translations = {
     habits: "Hábitos",
     add: "Agregar",
     buttonName: "Nombre del botón",
+    counts: "Contadores",
+    progress: "Progreso",
     showCounts: "Mostrar contadores",
     hideCounts: "Ocultar contadores",
     showProgress: "Mostrar progreso",
@@ -261,16 +265,20 @@ chartRange.innerHTML = `
 `;
 chartRange.value = "month";
 chartRange.addEventListener("change", drawChart);
-lblCounts.textContent = settings.showButtonCounts
-  ? t("hideCounts")
-  : t("showCounts");
-toggleCounts.textContent = settings.showButtonCounts ? "👁️" : "👁‍🚫";
-toggleCounts.setAttribute("aria-label", lblCounts.textContent);
-lblProgress.textContent = settings.showProgressCounter
-  ? t("hideProgress")
-  : t("showProgress");
-toggleProgress.textContent = settings.showProgressCounter ? "👁️" : "👁‍🚫";
-toggleProgress.setAttribute("aria-label", lblProgress.textContent);
+lblCounts.textContent = t("counts");
+toggleCounts.textContent = "👁️";
+toggleCounts.classList.toggle("off", !settings.showButtonCounts);
+toggleCounts.setAttribute(
+  "aria-label",
+  settings.showButtonCounts ? t("hideCounts") : t("showCounts"),
+);
+lblProgress.textContent = t("progress");
+toggleProgress.textContent = "👁️";
+toggleProgress.classList.toggle("off", !settings.showProgressCounter);
+toggleProgress.setAttribute(
+  "aria-label",
+  settings.showProgressCounter ? t("hideProgress") : t("showProgress"),
+);
 storageErrorText.textContent = t("storageError");
 
 // Init
@@ -700,17 +708,10 @@ function drawChart() {
 // HUD y Settings
 hudStatsBtn.addEventListener("click", () => {
   statsSheet.hidden = !statsSheet.hidden;
-  hudStatsBtn.textContent = statsSheet.hidden ? "👁‍🚫" : "👁️";
-  hudStatsBtn.setAttribute(
-    "aria-label",
-    statsSheet.hidden ? t("showStats") : t("stats"),
-  );
 });
 
 closeStats.addEventListener("click", () => {
   statsSheet.hidden = true;
-  hudStatsBtn.textContent = "👁‍🚫";
-  hudStatsBtn.setAttribute("aria-label", t("showStats"));
 });
 
 btnSettings.addEventListener("click", () => {
@@ -738,22 +739,22 @@ addButton.addEventListener("click", () => {
 toggleCounts.addEventListener("click", () => {
   settings.showButtonCounts = !settings.showButtonCounts;
   saveJSON(LS_SETTINGS, settings);
-  lblCounts.textContent = settings.showButtonCounts
-    ? t("hideCounts")
-    : t("showCounts");
-  toggleCounts.textContent = settings.showButtonCounts ? "👁️" : "👁‍🚫";
-  toggleCounts.setAttribute("aria-label", lblCounts.textContent);
+  toggleCounts.classList.toggle("off", !settings.showButtonCounts);
+  toggleCounts.setAttribute(
+    "aria-label",
+    settings.showButtonCounts ? t("hideCounts") : t("showCounts"),
+  );
   renderButtons();
 });
 
 toggleProgress.addEventListener("click", () => {
   settings.showProgressCounter = !settings.showProgressCounter;
   saveJSON(LS_SETTINGS, settings);
-  lblProgress.textContent = settings.showProgressCounter
-    ? t("hideProgress")
-    : t("showProgress");
-  toggleProgress.textContent = settings.showProgressCounter ? "👁️" : "👁‍🚫";
-  toggleProgress.setAttribute("aria-label", lblProgress.textContent);
+  toggleProgress.classList.toggle("off", !settings.showProgressCounter);
+  toggleProgress.setAttribute(
+    "aria-label",
+    settings.showProgressCounter ? t("hideProgress") : t("showProgress"),
+  );
   updateProgressCounter();
 });
 
@@ -808,16 +809,20 @@ notePlus.addEventListener("click", () => {
 });
 
 function renderSettings() {
-  lblCounts.textContent = settings.showButtonCounts
-    ? t("hideCounts")
-    : t("showCounts");
-  toggleCounts.textContent = settings.showButtonCounts ? "👁️" : "👁‍🚫";
-  toggleCounts.setAttribute("aria-label", lblCounts.textContent);
-  lblProgress.textContent = settings.showProgressCounter
-    ? t("hideProgress")
-    : t("showProgress");
-  toggleProgress.textContent = settings.showProgressCounter ? "👁️" : "👁‍🚫";
-  toggleProgress.setAttribute("aria-label", lblProgress.textContent);
+  lblCounts.textContent = t("counts");
+  toggleCounts.textContent = "👁️";
+  toggleCounts.classList.toggle("off", !settings.showButtonCounts);
+  toggleCounts.setAttribute(
+    "aria-label",
+    settings.showButtonCounts ? t("hideCounts") : t("showCounts"),
+  );
+  lblProgress.textContent = t("progress");
+  toggleProgress.textContent = "👁️";
+  toggleProgress.classList.toggle("off", !settings.showProgressCounter);
+  toggleProgress.setAttribute(
+    "aria-label",
+    settings.showProgressCounter ? t("hideProgress") : t("showProgress"),
+  );
 
   buttonList.innerHTML = "";
   settings.buttons.forEach((b, idx) => {

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
       <div id="progress-counter" hidden></div>
       <header id="hud">
         <button id="btn-settings" aria-label="Configuración">⚙️</button>
-        <button id="btn-stats" aria-label="Mostrar estadísticas">👁‍🚫</button>
+        <button id="btn-stats" aria-label="Mostrar estadísticas">📊</button>
       </header>
 
       <main id="scene">
@@ -82,15 +82,19 @@
             <button id="add-button">Agregar</button>
           </div>
           <div class="row">
-            <span id="lbl-counts">Mostrar contadores</span>
-            <button id="toggle-counts" aria-label="Mostrar contadores">
-              👁‍🚫
+            <span id="lbl-counts">Contadores</span>
+            <button id="toggle-counts" aria-label="Ocultar contadores">
+              👁️
             </button>
           </div>
           <div class="row">
-            <span id="lbl-progress">Mostrar progreso</span>
-            <button id="toggle-progress" aria-label="Mostrar progreso">
-              👁‍🚫
+            <span id="lbl-progress">Progreso</span>
+            <button
+              id="toggle-progress"
+              class="off"
+              aria-label="Mostrar progreso"
+            >
+              👁️
             </button>
           </div>
           <h3 id="settings-advanced">Avanzado</h3>

--- a/style.css
+++ b/style.css
@@ -319,6 +319,7 @@ body {
 
 #reset-app {
   background: #ff6666;
+  color: #000000;
 }
 
 #refresh-app {
@@ -326,18 +327,36 @@ body {
   color: #000000;
 }
 
+#toggle-counts,
 #toggle-progress {
   background: none;
   color: inherit;
   padding: 0;
   box-shadow: none;
   font-size: 24px;
+  position: relative;
 }
 
+#toggle-counts:hover,
+#toggle-counts:active,
 #toggle-progress:hover,
 #toggle-progress:active {
   transform: none;
   box-shadow: none;
+}
+
+#toggle-counts.off::after,
+#toggle-progress.off::after {
+  content: "🚫";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
 }
 
 #stats #close-stats {


### PR DESCRIPTION
## Summary
- Revert HUD stats button to bar-chart icon and simplify toggle logic
- Show constant "Contadores" and "Progreso" labels with crossed-eye overlay when hidden
- Make "Renacer" button text black for better contrast

## Testing
- `npx prettier --check app.js index.html style.css`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a169579a90832eb03b79581bf8451e